### PR TITLE
Adding linting rules to enforce jsdocs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,18 @@ module.exports = {
     "react/self-closing-comp": 0,
     "react/prop-types": 0,
     "react/prefer-stateless-function": 1,
-    "require-yield": 0
+    "require-yield": 0,
+	"require-jsdoc": ["error", {
+        "require": {
+            "FunctionDeclaration": true,
+            "MethodDefinition": true,
+            "ClassDeclaration": true,
+            "ArrowFunctionExpression": false // Arrow functions are used mainly for callbacks (?) TBD
+        }
+    }],
+	"valid-jsdoc": ["error", { //tbd http://eslint.org/docs/rules/valid-jsdoc
+		"requireReturn": false, // only add @return if the method has one -> instead of @return {void}
+		"requireParamDescription": true
+	}]
   }
 };


### PR DESCRIPTION
My comments on the ruleset:

- I think no one uses Arrow Functions for creating components, classes etc. anyway so documenting them is optional. But Function declarations (Es6 class methods), Class Declarations and Methods should be documented and therefore required.

I've also added 'valid-jsdoc' check to make sure that our jsdocs are also valid. Currently, it is only defined that @return is not necessary when there is no return in the method and everything has to have a description. 
If you're interested we can also add here a 'prefer' option which forces everyone to use the same jsdoc tags http://eslint.org/docs/rules/valid-jsdoc#options