### PR TITLE
Tile chart: Simplify the properties and allow tile styling using css

### DIFF
--- a/demo/demo_app.js
+++ b/demo/demo_app.js
@@ -78,8 +78,7 @@ render(
         </tbody>
       </table>
       <br />
-        <WSTilesChart title="Chart title" data={dashboardMockData.data} width={100} height={100}
-        />
+        <WSTilesChart title="Chart title" data={dashboardMockData.data} width={100} height={100} />
     </div>
   </div>
 , document.querySelector('#app-holder'));

--- a/demo/demo_app.js
+++ b/demo/demo_app.js
@@ -78,8 +78,7 @@ render(
         </tbody>
       </table>
       <br />
-        <WSTilesChart
-          title="Chart title" data={dashboardMockData.data} config={dashboardMockData.config} width={100} height={100}
+        <WSTilesChart title="Chart title" data={dashboardMockData.data} width={100} height={100}
         />
     </div>
   </div>

--- a/demo/index.scss
+++ b/demo/index.scss
@@ -11,3 +11,14 @@ $use-embedded-font: true;
 .container {
   margin: 20px;
 }
+
+
+//Example of how to style ws-tiles-chart using classes (.tile.groupName).
+.ws-tiles-chart .tile {
+  &.from2hTo1Day {
+    background-color: $grandis;
+  }
+  &.moreThan1Day {
+    background-color: $flamingo;
+  }
+}

--- a/demo/mockdata.js
+++ b/demo/mockdata.js
@@ -1,24 +1,15 @@
 export const dashboardMockData = {
   data: {
-    groups: [{
-      key: 'lessThan2h',
-      tilesSet: [{key: '1'}, {key: '2'}, {key: '3'}, {key: '4'}, {key: '5'}]
-    },
-      {
-        key: 'from2hTo1Day',
-        tilesSet: [{key: '6'}, {key: '7'}, {key: '8'}, {key: '9'}, {key: '10'}]
-      },
-      {
-        key: 'moreThan1Day',
-        tilesSet: [{key: '11'}, {key: '12'}, {key: '13'}, {key: '14'},
-          {key: '15'}, {key: '15'}]
-      }]
+    groups: {
+      lessThan2h: ['1', '2', '3', 'd', 'e'],
+      from2hTo1Day: ['c', 'x', 'v', 'r', 'z'],
+      moreThan1Day: ['t', 'r', 'g', 'l', '5', '6']
+    }
   },
   config: {
-    groupConfigs: [
-      {key: 'lessThan2h', backgroundColor: '#FF4D4D'},
-      {key: 'from2hTo1Day', backgroundColor: '#ffcc33'},
-      {key: 'moreThan1Day', backgroundColor: '#39AC39'}
-    ]
+    lessThan2h:'#FF4D4D',
+    from2hTo1Day: '#ffcc33',
+    moreThan1Day: '#39AC39'
   }
+
 }

--- a/demo/mockdata.js
+++ b/demo/mockdata.js
@@ -5,11 +5,5 @@ export const dashboardMockData = {
       from2hTo1Day: ['c', 'x', 'v', 'r', 'z'],
       moreThan1Day: ['t', 'r', 'g', 'l', '5', '6']
     }
-  },
-  config: {
-    lessThan2h:'#FF4D4D',
-    from2hTo1Day: '#ffcc33',
-    moreThan1Day: '#39AC39'
   }
-
 }

--- a/dist/amd/ws-tiles-chart/tile.js
+++ b/dist/amd/ws-tiles-chart/tile.js
@@ -79,12 +79,12 @@ define(['exports', 'react', '../imports'], function (exports, _react, _imports) 
             size = _props.size;
 
         var style = {
-          backgroundColor: config.backgroundColor,
+          backgroundColor: config,
           width: size + 'px',
           height: size + 'px'
         };
 
-        return _react2.default.createElement('div', { className: 'tile', style: style });
+        return _react2.default.createElement('div', { className: 'tile ' + this.props.tileClass, style: style });
       }
     }]);
 
@@ -95,8 +95,9 @@ define(['exports', 'react', '../imports'], function (exports, _react, _imports) 
     enumerable: true,
     writable: true,
     value: {
-      data: _imports.PropTypes.object,
-      config: _imports.PropTypes.object,
+      identifier: _imports.PropTypes.string,
+      config: _imports.PropTypes.string,
+      tileClass: _imports.PropTypes.string,
       size: _imports.PropTypes.number
     }
   });
@@ -104,8 +105,9 @@ define(['exports', 'react', '../imports'], function (exports, _react, _imports) 
     enumerable: true,
     writable: true,
     value: {
-      data: {},
-      config: {},
+      identifier: '',
+      config: '',
+      tileClass: '',
       size: 25
     }
   });

--- a/dist/amd/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/amd/ws-tiles-chart/ws-tiles-chart.js
@@ -83,16 +83,6 @@ define(['exports', 'react', '../imports', './tile'], function (exports, _react, 
         this.setState({ tileSize: this.getTileSize() });
       }
     }, {
-      key: 'getGroupConfig',
-      value: function getGroupConfig(config, group) {
-        if (config.groupConfigs) {
-          return config.groupConfigs.find(function (groupConfig) {
-            return groupConfig.key === group.key;
-          });
-        }
-        return {};
-      }
-    }, {
       key: 'getTileSize',
       value: function getTileSize() {
         var groups = this.props.data.groups || {};

--- a/dist/amd/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/amd/ws-tiles-chart/ws-tiles-chart.js
@@ -95,8 +95,9 @@ define(['exports', 'react', '../imports', './tile'], function (exports, _react, 
     }, {
       key: 'getTileSize',
       value: function getTileSize() {
-        var tilesAmount = this.props.data.groups.map(function (group) {
-          return group.tilesSet.length;
+        var groups = this.props.data.groups || {};
+        var tilesAmount = Object.keys(groups).map(function (groupName) {
+          return groups[groupName].length;
         }).reduce(function (a, b) {
           return a + b;
         });
@@ -129,6 +130,7 @@ define(['exports', 'react', '../imports', './tile'], function (exports, _react, 
             width = _props.width,
             height = _props.height;
 
+        var groups = data.groups || {};
         return _react2.default.createElement(
           'div',
           { className: 'ws-tiles-chart', style: { width: width + 'px', height: height + 'px' } },
@@ -140,11 +142,12 @@ define(['exports', 'react', '../imports', './tile'], function (exports, _react, 
           _react2.default.createElement(
             'div',
             { className: 'tiles-chart-container', style: { height: height - this.titleDivSize + 'px' } },
-            data.groups.map(function (group) {
-              return group.tilesSet.map(function (tile) {
+            Object.keys(groups).map(function (groupName) {
+              return groups[groupName].map(function (tile) {
                 return _react2.default.createElement(_tile.Tile, {
                   data: tile,
-                  config: _this2.getGroupConfig(config, group),
+                  tileClass: groupName,
+                  config: config[groupName],
                   size: _this2.state.tileSize
                 });
               });

--- a/dist/amd/ws-tiles-chart/ws-tiles-chart.scss
+++ b/dist/amd/ws-tiles-chart/ws-tiles-chart.scss
@@ -13,6 +13,7 @@
     .tile {
       box-sizing: border-box;
       border: 1px solid white;
+      background-color: $forest-green;
     }
   }
 }

--- a/dist/commonjs/ws-tiles-chart/tile.js
+++ b/dist/commonjs/ws-tiles-chart/tile.js
@@ -38,12 +38,12 @@ var Tile = exports.Tile = function (_Component) {
           size = _props.size;
 
       var style = {
-        backgroundColor: config.backgroundColor,
+        backgroundColor: config,
         width: size + 'px',
         height: size + 'px'
       };
 
-      return _react2.default.createElement('div', { className: 'tile', style: style });
+      return _react2.default.createElement('div', { className: 'tile ' + this.props.tileClass, style: style });
     }
   }]);
 
@@ -54,8 +54,9 @@ Object.defineProperty(Tile, 'propTypes', {
   enumerable: true,
   writable: true,
   value: {
-    data: _imports.PropTypes.object,
-    config: _imports.PropTypes.object,
+    identifier: _imports.PropTypes.string,
+    config: _imports.PropTypes.string,
+    tileClass: _imports.PropTypes.string,
     size: _imports.PropTypes.number
   }
 });
@@ -63,8 +64,9 @@ Object.defineProperty(Tile, 'defaultProps', {
   enumerable: true,
   writable: true,
   value: {
-    data: {},
-    config: {},
+    identifier: '',
+    config: '',
+    tileClass: '',
     size: 25
   }
 });

--- a/dist/commonjs/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/commonjs/ws-tiles-chart/ws-tiles-chart.js
@@ -44,16 +44,6 @@ var WSTilesChart = exports.WSTilesChart = function (_Component) {
       this.setState({ tileSize: this.getTileSize() });
     }
   }, {
-    key: 'getGroupConfig',
-    value: function getGroupConfig(config, group) {
-      if (config.groupConfigs) {
-        return config.groupConfigs.find(function (groupConfig) {
-          return groupConfig.key === group.key;
-        });
-      }
-      return {};
-    }
-  }, {
     key: 'getTileSize',
     value: function getTileSize() {
       var groups = this.props.data.groups || {};

--- a/dist/commonjs/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/commonjs/ws-tiles-chart/ws-tiles-chart.js
@@ -56,8 +56,9 @@ var WSTilesChart = exports.WSTilesChart = function (_Component) {
   }, {
     key: 'getTileSize',
     value: function getTileSize() {
-      var tilesAmount = this.props.data.groups.map(function (group) {
-        return group.tilesSet.length;
+      var groups = this.props.data.groups || {};
+      var tilesAmount = Object.keys(groups).map(function (groupName) {
+        return groups[groupName].length;
       }).reduce(function (a, b) {
         return a + b;
       });
@@ -90,6 +91,7 @@ var WSTilesChart = exports.WSTilesChart = function (_Component) {
           width = _props.width,
           height = _props.height;
 
+      var groups = data.groups || {};
       return _react2.default.createElement(
         'div',
         { className: 'ws-tiles-chart', style: { width: width + 'px', height: height + 'px' } },
@@ -101,11 +103,12 @@ var WSTilesChart = exports.WSTilesChart = function (_Component) {
         _react2.default.createElement(
           'div',
           { className: 'tiles-chart-container', style: { height: height - this.titleDivSize + 'px' } },
-          data.groups.map(function (group) {
-            return group.tilesSet.map(function (tile) {
+          Object.keys(groups).map(function (groupName) {
+            return groups[groupName].map(function (tile) {
               return _react2.default.createElement(_tile.Tile, {
                 data: tile,
-                config: _this2.getGroupConfig(config, group),
+                tileClass: groupName,
+                config: config[groupName],
                 size: _this2.state.tileSize
               });
             });

--- a/dist/commonjs/ws-tiles-chart/ws-tiles-chart.scss
+++ b/dist/commonjs/ws-tiles-chart/ws-tiles-chart.scss
@@ -13,6 +13,7 @@
     .tile {
       box-sizing: border-box;
       border: 1px solid white;
+      background-color: $forest-green;
     }
   }
 }

--- a/dist/es2015/ws-tiles-chart/tile.js
+++ b/dist/es2015/ws-tiles-chart/tile.js
@@ -26,12 +26,12 @@ export var Tile = function (_Component) {
           size = _props.size;
 
       var style = {
-        backgroundColor: config.backgroundColor,
+        backgroundColor: config,
         width: size + 'px',
         height: size + 'px'
       };
 
-      return React.createElement('div', { className: 'tile', style: style });
+      return React.createElement('div', { className: 'tile ' + this.props.tileClass, style: style });
     }
   }]);
 
@@ -41,8 +41,9 @@ Object.defineProperty(Tile, 'propTypes', {
   enumerable: true,
   writable: true,
   value: {
-    data: PropTypes.object,
-    config: PropTypes.object,
+    identifier: PropTypes.string,
+    config: PropTypes.string,
+    tileClass: PropTypes.string,
     size: PropTypes.number
   }
 });
@@ -50,8 +51,9 @@ Object.defineProperty(Tile, 'defaultProps', {
   enumerable: true,
   writable: true,
   value: {
-    data: {},
-    config: {},
+    identifier: '',
+    config: '',
+    tileClass: '',
     size: 25
   }
 });

--- a/dist/es2015/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/es2015/ws-tiles-chart/ws-tiles-chart.js
@@ -43,8 +43,9 @@ export var WSTilesChart = function (_Component) {
   }, {
     key: 'getTileSize',
     value: function getTileSize() {
-      var tilesAmount = this.props.data.groups.map(function (group) {
-        return group.tilesSet.length;
+      var groups = this.props.data.groups || {};
+      var tilesAmount = Object.keys(groups).map(function (groupName) {
+        return groups[groupName].length;
       }).reduce(function (a, b) {
         return a + b;
       });
@@ -77,6 +78,7 @@ export var WSTilesChart = function (_Component) {
           width = _props.width,
           height = _props.height;
 
+      var groups = data.groups || {};
       return React.createElement(
         'div',
         { className: 'ws-tiles-chart', style: { width: width + 'px', height: height + 'px' } },
@@ -88,11 +90,12 @@ export var WSTilesChart = function (_Component) {
         React.createElement(
           'div',
           { className: 'tiles-chart-container', style: { height: height - this.titleDivSize + 'px' } },
-          data.groups.map(function (group) {
-            return group.tilesSet.map(function (tile) {
+          Object.keys(groups).map(function (groupName) {
+            return groups[groupName].map(function (tile) {
               return React.createElement(Tile, {
                 data: tile,
-                config: _this2.getGroupConfig(config, group),
+                tileClass: groupName,
+                config: config[groupName],
                 size: _this2.state.tileSize
               });
             });

--- a/dist/es2015/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/es2015/ws-tiles-chart/ws-tiles-chart.js
@@ -31,16 +31,6 @@ export var WSTilesChart = function (_Component) {
       this.setState({ tileSize: this.getTileSize() });
     }
   }, {
-    key: 'getGroupConfig',
-    value: function getGroupConfig(config, group) {
-      if (config.groupConfigs) {
-        return config.groupConfigs.find(function (groupConfig) {
-          return groupConfig.key === group.key;
-        });
-      }
-      return {};
-    }
-  }, {
     key: 'getTileSize',
     value: function getTileSize() {
       var groups = this.props.data.groups || {};

--- a/dist/es2015/ws-tiles-chart/ws-tiles-chart.scss
+++ b/dist/es2015/ws-tiles-chart/ws-tiles-chart.scss
@@ -13,6 +13,7 @@
     .tile {
       box-sizing: border-box;
       border: 1px solid white;
+      background-color: $forest-green;
     }
   }
 }

--- a/dist/system/ws-tiles-chart/tile.js
+++ b/dist/system/ws-tiles-chart/tile.js
@@ -76,12 +76,12 @@ System.register(['react', '../imports'], function (_export, _context) {
                 size = _props.size;
 
             var style = {
-              backgroundColor: config.backgroundColor,
+              backgroundColor: config,
               width: size + 'px',
               height: size + 'px'
             };
 
-            return React.createElement('div', { className: 'tile', style: style });
+            return React.createElement('div', { className: 'tile ' + this.props.tileClass, style: style });
           }
         }]);
 
@@ -94,8 +94,9 @@ System.register(['react', '../imports'], function (_export, _context) {
         enumerable: true,
         writable: true,
         value: {
-          data: PropTypes.object,
-          config: PropTypes.object,
+          identifier: PropTypes.string,
+          config: PropTypes.string,
+          tileClass: PropTypes.string,
           size: PropTypes.number
         }
       });
@@ -103,8 +104,9 @@ System.register(['react', '../imports'], function (_export, _context) {
         enumerable: true,
         writable: true,
         value: {
-          data: {},
-          config: {},
+          identifier: '',
+          config: '',
+          tileClass: '',
           size: 25
         }
       });

--- a/dist/system/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/system/ws-tiles-chart/ws-tiles-chart.js
@@ -94,8 +94,9 @@ System.register(['react', '../imports', './tile'], function (_export, _context) 
         }, {
           key: 'getTileSize',
           value: function getTileSize() {
-            var tilesAmount = this.props.data.groups.map(function (group) {
-              return group.tilesSet.length;
+            var groups = this.props.data.groups || {};
+            var tilesAmount = Object.keys(groups).map(function (groupName) {
+              return groups[groupName].length;
             }).reduce(function (a, b) {
               return a + b;
             });
@@ -128,6 +129,7 @@ System.register(['react', '../imports', './tile'], function (_export, _context) 
                 width = _props.width,
                 height = _props.height;
 
+            var groups = data.groups || {};
             return React.createElement(
               'div',
               { className: 'ws-tiles-chart', style: { width: width + 'px', height: height + 'px' } },
@@ -139,11 +141,12 @@ System.register(['react', '../imports', './tile'], function (_export, _context) 
               React.createElement(
                 'div',
                 { className: 'tiles-chart-container', style: { height: height - this.titleDivSize + 'px' } },
-                data.groups.map(function (group) {
-                  return group.tilesSet.map(function (tile) {
+                Object.keys(groups).map(function (groupName) {
+                  return groups[groupName].map(function (tile) {
                     return React.createElement(Tile, {
                       data: tile,
-                      config: _this2.getGroupConfig(config, group),
+                      tileClass: groupName,
+                      config: config[groupName],
                       size: _this2.state.tileSize
                     });
                   });

--- a/dist/system/ws-tiles-chart/ws-tiles-chart.js
+++ b/dist/system/ws-tiles-chart/ws-tiles-chart.js
@@ -82,16 +82,6 @@ System.register(['react', '../imports', './tile'], function (_export, _context) 
             this.setState({ tileSize: this.getTileSize() });
           }
         }, {
-          key: 'getGroupConfig',
-          value: function getGroupConfig(config, group) {
-            if (config.groupConfigs) {
-              return config.groupConfigs.find(function (groupConfig) {
-                return groupConfig.key === group.key;
-              });
-            }
-            return {};
-          }
-        }, {
           key: 'getTileSize',
           value: function getTileSize() {
             var groups = this.props.data.groups || {};

--- a/dist/system/ws-tiles-chart/ws-tiles-chart.scss
+++ b/dist/system/ws-tiles-chart/ws-tiles-chart.scss
@@ -13,6 +13,7 @@
     .tile {
       box-sizing: border-box;
       border: 1px solid white;
+      background-color: $forest-green;
     }
   }
 }

--- a/src/ws-tiles-chart/tile.js
+++ b/src/ws-tiles-chart/tile.js
@@ -4,7 +4,9 @@ import {Component, PropTypes} from '../imports';
 /**
  * This class describes a Preact/React component which renders a single tile
  * @property {Object} props React properties object
- * @property {Object} props.config Defines the configuration of the tile, e.g. the background color
+ * @property {Object} props.identifier identifier of the tile
+ * @property {Object} props.config Defines the background color of the tile
+ * @property {Object} props.tileClass The class of the tile which can also be used for color styling
  * @property {number} props.size Defines the width and height of the tile
  */
 export class Tile extends Component {
@@ -13,8 +15,9 @@ export class Tile extends Component {
    * @type {Object}
    */
   static propTypes = {
-    data: PropTypes.object,
-    config: PropTypes.object,
+    identifier: PropTypes.string,
+    config: PropTypes.string,
+    tileClass: PropTypes.string,
     size: PropTypes.number
   };
 
@@ -23,8 +26,9 @@ export class Tile extends Component {
    * @type {Object}
    */
   static defaultProps = {
-    data: {},
-    config: {},
+    identifier: '',
+    config: '',
+    tileClass: '',
     size: 25
   };
 
@@ -35,13 +39,13 @@ export class Tile extends Component {
   render() {
     const {config, size} = this.props;
     const style = {
-      backgroundColor: config.backgroundColor,
+      backgroundColor: config,
       width: `${size}px`,
       height: `${size}px`
     };
 
     return (
-      <div className="tile" style={style} />
+      <div className={`tile ${this.props.tileClass}`} style={style} />
     );
   }
 }

--- a/src/ws-tiles-chart/ws-tiles-chart.js
+++ b/src/ws-tiles-chart/ws-tiles-chart.js
@@ -7,7 +7,7 @@ import {Tile} from './tile';
  * @class WSTilesChart
  * @property {Object} props React properties object
  * @property {Object} props.data Defines the Groups of tiles that should be shown in the chart
- * @property {Object} props.config Defines the configuration of the component, e.g. the color of each group of tiles
+ * @property {Object} props.config Defines the color of each group of tiles
  * @property {string} props.title Title of the chart
  * @property {number} props.maxTileSize Defines the maximum size that the tile can be
  *
@@ -77,7 +77,8 @@ export class WSTilesChart extends Component {
    * @returns {number}
    */
   getTileSize() {
-    const tilesAmount = this.props.data.groups.map(group => group.tilesSet.length).reduce((a, b) => a + b);
+    const groups = this.props.data.groups || {};
+    const tilesAmount = Object.keys(groups).map(groupName => groups[groupName].length).reduce((a, b) => a + b);
 
     const tileSize = this.calculateMaximumPossibleTileSize(
       this.props.width, this.props.height - this.titleDivSize, tilesAmount
@@ -110,14 +111,16 @@ export class WSTilesChart extends Component {
    */
   render() {
     const {data, config, title, width, height} = this.props;
+    const groups = data.groups || {};
     return (
       <div className="ws-tiles-chart" style={{width: `${width}px`, height: `${height}px`}}>
         <div className="tiles-chart-title">{title}</div>
         <div className="tiles-chart-container" style={{height: `${height - this.titleDivSize}px`}}>
-          {data.groups.map(group => group.tilesSet.map(tile =>
+          {Object.keys(groups).map(groupName => groups[groupName].map(tile =>
             <Tile
               data={tile}
-              config={this.getGroupConfig(config, group)}
+              tileClass={groupName}
+              config={config[groupName]}
               size={this.state.tileSize}
             />
           ))}

--- a/src/ws-tiles-chart/ws-tiles-chart.js
+++ b/src/ws-tiles-chart/ws-tiles-chart.js
@@ -60,19 +60,6 @@ export class WSTilesChart extends Component {
   }
 
   /**
-   * Finds the config of the group
-   * @param {array} config Array of group configurations
-   * @param {object} group to be filtered
-   * @returns {object}
-   */
-  getGroupConfig(config, group) {
-    if (config.groupConfigs) {
-      return config.groupConfigs.find(groupConfig => groupConfig.key === group.key);
-    }
-    return {};
-  }
-
-  /**
    * Returns the size to be used for the tile
    * @returns {number}
    */

--- a/src/ws-tiles-chart/ws-tiles-chart.scss
+++ b/src/ws-tiles-chart/ws-tiles-chart.scss
@@ -13,6 +13,7 @@
     .tile {
       box-sizing: border-box;
       border: 1px solid white;
+      background-color: $forest-green;
     }
   }
 }


### PR DESCRIPTION
Tile Chart: Simplify properties and allow tile CSS styling per group

- Simplify the data property passed to the component
- Add the group name as a class to the tile in order to allow styling using CSS
- Add a default tile color to the CSS
- Change Demo page to show how to style the tiles per group using CSS instead of property