### PR TITLE
fix(notification): removeEventListener should have 2 arguments not one

### DIFF
--- a/src/ws-notification/ws-notification.js
+++ b/src/ws-notification/ws-notification.js
@@ -62,8 +62,8 @@ export class WSNotification extends Component {
    * @returns {void}
    */
   componentWillUnmount() {
-    window.removeEventListener('ws-notification-open');
-    window.removeEventListener('ws-notification-close');
+    window.removeEventListener('ws-notification-open', this.addNotify);
+    window.removeEventListener('ws-notification-close', this.closeAllEvents);
   }
 
   /**


### PR DESCRIPTION
<img width="946" alt="screen shot 2017-07-21 at 14 24 00" src="https://user-images.githubusercontent.com/1137569/28463356-447eaf0c-6e20-11e7-9806-60c4c0c6123e.png">

Sometimes this error pops up in applications using ws-notification, due to having only one parameter so I added the 2nd one to fix it.