### PR TITLE
fix(header): Fixed wrong key name for local storage

### DIFF
--- a/src/ws-header/storage/local-storage.js
+++ b/src/ws-header/storage/local-storage.js
@@ -13,7 +13,7 @@ export class LocalStorage extends AbstractStorage {
    */
   set(key, value) {
     const encodedValue = encodeURIComponent(JSON.stringify(value));
-    localStorage.setItem(`${name}${key}`, encodedValue);
+    localStorage.setItem(`${this.name}${key}`, encodedValue);
   }
 
   /**
@@ -22,7 +22,7 @@ export class LocalStorage extends AbstractStorage {
    * @returns {*}
    */
   get(key) {
-    const encodedValue = localStorage.getItem(key);
+    const encodedValue = localStorage.getItem(`${this.name}${key}`);
 
     if (encodedValue) {
       try {


### PR DESCRIPTION
The local storage was using a wrong key and therefore the login could be not working.